### PR TITLE
Fixes the dataview query to display ac

### DIFF
--- a/1-DM Toolkit/DM Board.md
+++ b/1-DM Toolkit/DM Board.md
@@ -3,7 +3,7 @@ obsidianUIMode: preview
 ---
 
 ```dataview
-TABLE WITHOUT ID link(file.name) AS "Character Name", Player, AC, pasperc As "Pass Perc (WIS)"
+TABLE WITHOUT ID link(file.name) AS "Character Name", Player, ac, pasperc As "Pass Perc (WIS)"
 from "1-Party"
 where contains(Role, "Player") 
 where contains(Status, "Active")


### PR DESCRIPTION
The 'New Player' button calls z_Templates/TemplatePlayer which contains a dataview attribute for a lowercase 'ac'. Modify the dataview query to user correct capitalization like the '1-Party/Example Party 1' query to actually show the player ac values